### PR TITLE
Add navigation event for navigator (OSK-7)

### DIFF
--- a/src/OSK.DataStructures.UnitTests/CollectionNavigatorTests.cs
+++ b/src/OSK.DataStructures.UnitTests/CollectionNavigatorTests.cs
@@ -1,4 +1,7 @@
-﻿namespace OSK.DataStructures.UnitTests;
+﻿using System.Collections.Generic;
+using OSK.DataStructures.Events;
+
+namespace OSK.DataStructures.UnitTests;
 
 public class CollectionNavigatorTests
 {
@@ -62,8 +65,15 @@ public class CollectionNavigatorTests
         Assert.Equal(2, navigator.Count);
         Assert.Equal("a", navigator.Current);
         Assert.Equal(0, navigator.CurrentIndex);
-        Assert.Equal(wrap, navigator.HasPrevious);
         Assert.True(navigator.HasNext);
+        if (wrap)
+        {
+            Assert.True(navigator.HasPrevious);
+        }
+        else
+        {
+            Assert.False(navigator.HasPrevious);
+        }
     }
 
     #endregion
@@ -154,6 +164,16 @@ public class CollectionNavigatorTests
         Assert.Equal("c", navigator.Current);
     }
 
+    [Fact]
+    public void Current_EmptyCollection_ReturnsDefault()
+    {
+        // Arrange
+        var navigator = new CollectionNavigator<string>(Array.Empty<string>());
+
+        // Act & Assert
+        Assert.Null(navigator.Current);
+    }
+
     #endregion
 
     #region CurrentIndex
@@ -224,26 +244,19 @@ public class CollectionNavigatorTests
     }
 
     [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public void HasNext_AtEnd_ReturnsExpected(bool wrap)
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    public void HasNext_AtEnd_ReturnsExpected(bool wrap, bool expected)
     {
         // Arrange
         var navigator = new CollectionNavigator<string>(_items, wrap);
-        for (int i = 0; i < _items.Count; i++)
+        for (int i = 0; i < _items.Count - 1; i++)
         {
             navigator.Next();
         }
 
         // Act & Assert
-        if (wrap)
-        {
-            Assert.True(navigator.HasNext);
-        }
-        else
-        {
-            Assert.False(navigator.HasNext);
-        }
+        Assert.Equal(expected, navigator.HasNext);
     }
 
     #endregion
@@ -261,22 +274,31 @@ public class CollectionNavigatorTests
     }
 
     [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public void HasPrevious_AtStart_ReturnsExpected(bool wrap)
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public void HasPrevious_AtEnd_ReturnsExpected(bool wrap, bool expected)
+    {
+        // Arrange
+        var navigator = new CollectionNavigator<string>(_items, wrap);
+        for (int i = 0; i < _items.Count - 1; i++)
+        {
+            navigator.Next();
+        }
+
+        // Act & Assert
+        Assert.Equal(expected, navigator.HasPrevious);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    public void HasPrevious_AtStart_ReturnsExpected(bool wrap, bool expected)
     {
         // Arrange
         var navigator = new CollectionNavigator<string>(_items, wrap);
 
         // Act & Assert
-        if (wrap)
-        {
-            Assert.True(navigator.HasPrevious);
-        }
-        else
-        {
-            Assert.False(navigator.HasPrevious);
-        }
+        Assert.Equal(expected, navigator.HasPrevious);
     }
 
     #endregion
@@ -319,7 +341,7 @@ public class CollectionNavigatorTests
     {
         // Arrange
         var navigator = new CollectionNavigator<string>(_items, false);
-        for (int i = 0; i < _items.Count; i++)
+        for (int i = 0; i < _items.Count - 1; i++)
         {
             navigator.Next();
         }
@@ -511,7 +533,10 @@ public class CollectionNavigatorTests
     public void TryNavigate_ValidIndex_NavigatesSuccessfully(int index)
     {
         // Arrange
+        var raisedEvent = false;
         var navigator = new CollectionNavigator<string>(_items);
+
+        navigator.Navigated += _ => raisedEvent = true;
 
         // Act
         var result = navigator.TryNavigate(index);
@@ -520,6 +545,7 @@ public class CollectionNavigatorTests
         Assert.True(result);
         Assert.Equal(_items[index], navigator.Current);
         Assert.Equal(index, navigator.CurrentIndex);
+        Assert.True(raisedEvent);
     }
 
     [Theory]
@@ -570,7 +596,7 @@ public class CollectionNavigatorTests
     {
         // Arrange
         var navigator = new CollectionNavigator<string>(_items);
-        for (int i = 0; i < _items.Count; i++)
+        for (int i = 0; i < _items.Count - 1; i++)
         {
             navigator.Next();
         }
@@ -600,6 +626,203 @@ public class CollectionNavigatorTests
 
         // Assert
         Assert.Equal(wrap, navigator.WrapNavigation);
+    }
+
+    #endregion
+
+    #region Navigated
+
+    [Fact]
+    public void Navigated_OnNext_FiresWithCorrectPayload()
+    {
+        // Arrange
+        var navigator = new CollectionNavigator<string>(_items);
+        CollectionNavigationEvent<string>? capturedEvent = null;
+        navigator.Navigated += @event => capturedEvent = @event;
+
+        // Act
+        navigator.Next();
+
+        // Assert
+        Assert.NotNull(capturedEvent);
+        Assert.Equal("b", capturedEvent.Current);
+        Assert.Equal(1, capturedEvent.CurrentIndex);
+        Assert.Equal(5, capturedEvent.TotalItems);
+    }
+
+    [Fact]
+    public void Navigated_OnPrevious_FiresWithCorrectPayload()
+    {
+        // Arrange
+        var navigator = new CollectionNavigator<string>(_items);
+        for (int i = 0; i < _items.Count - 1; i++)
+        {
+            navigator.Next();
+        }
+
+        CollectionNavigationEvent<string>? capturedEvent = null;
+        navigator.Navigated += @event => capturedEvent = @event;
+
+        // Act
+        navigator.Previous();
+
+        // Assert
+        Assert.NotNull(capturedEvent);
+        Assert.Equal(_items[_items.Count - 2], capturedEvent.Current);
+        Assert.Equal(_items.Count - 2, capturedEvent.CurrentIndex);
+        Assert.Equal(5, capturedEvent.TotalItems);
+    }
+
+    [Fact]
+    public void Navigated_OnTryNavigate_FiresWithCorrectPayload()
+    {
+        // Arrange
+        var navigator = new CollectionNavigator<string>(_items);
+        CollectionNavigationEvent<string>? capturedEvent = null;
+        navigator.Navigated += @event => capturedEvent = @event;
+
+        // Act
+        navigator.TryNavigate(3);
+
+        // Assert
+        Assert.NotNull(capturedEvent);
+        Assert.Equal("d", capturedEvent.Current);
+        Assert.Equal(3, capturedEvent.CurrentIndex);
+        Assert.Equal(5, capturedEvent.TotalItems);
+    }
+
+    [Fact]
+    public void Navigated_OnWrapNavigation_FiresWithCorrectPayload()
+    {
+        // Arrange
+        var navigator = new CollectionNavigator<string>(_items, true);
+        for (int i = 0; i < _items.Count - 1; i++)
+        {
+            navigator.Next();
+        }
+
+        CollectionNavigationEvent<string>? capturedEvent = null;
+        navigator.Navigated += @event => capturedEvent = @event;
+
+        // Act
+        navigator.Next();
+
+        // Assert
+        Assert.NotNull(capturedEvent);
+        Assert.Equal("a", capturedEvent.Current);
+        Assert.Equal(0, capturedEvent.CurrentIndex);
+        Assert.Equal(5, capturedEvent.TotalItems);
+    }
+
+    [Fact]
+    public void Navigated_OnWrapPrevious_FiresWithCorrectPayload()
+    {
+        // Arrange
+        var navigator = new CollectionNavigator<string>(_items, true);
+
+        CollectionNavigationEvent<string>? capturedEvent = null;
+        navigator.Navigated += @event => capturedEvent = @event;
+
+        // Act
+        navigator.Previous();
+
+        // Assert
+        Assert.NotNull(capturedEvent);
+        Assert.Equal("e", capturedEvent.Current);
+        Assert.Equal(4, capturedEvent.CurrentIndex);
+        Assert.Equal(5, capturedEvent.TotalItems);
+    }
+
+    [Fact]
+    public void Navigated_OnFailedNext_DoesNotFire()
+    {
+        // Arrange
+        var navigator = new CollectionNavigator<string>(_items, false);
+        for (int i = 0; i < _items.Count - 1; i++)
+        {
+            navigator.Next();
+        }
+
+        int callCount = 0;
+        navigator.Navigated += @event => callCount++;
+
+        // Act
+        navigator.Next();
+
+        // Assert
+        Assert.Equal(0, callCount);
+    }
+
+    [Fact]
+    public void Navigated_OnFailedPrevious_DoesNotFire()
+    {
+        // Arrange
+        var navigator = new CollectionNavigator<string>(_items, false);
+
+        int callCount = 0;
+        navigator.Navigated += @event => callCount++;
+
+        // Act
+        navigator.Previous();
+
+        // Assert
+        Assert.Equal(0, callCount);
+    }
+
+    [Fact]
+    public void Navigated_OnFailedTryNavigate_DoesNotFire()
+    {
+        // Arrange
+        var navigator = new CollectionNavigator<string>(_items);
+
+        int callCount = 0;
+        navigator.Navigated += @event => callCount++;
+
+        // Act
+        navigator.TryNavigate(100);
+
+        // Assert
+        Assert.Equal(0, callCount);
+    }
+
+    [Fact]
+    public void Navigated_OnMultipleNavigations_FiresEachTime()
+    {
+        // Arrange
+        var navigator = new CollectionNavigator<string>(_items);
+        int callCount = 0;
+
+        var multiDelegateFired = false;
+
+        navigator.Navigated += @event => callCount++;
+        navigator.Navigated += _ => multiDelegateFired = true;
+
+        // Act
+        navigator.Next();
+        navigator.Next();
+        navigator.Previous();
+        navigator.TryNavigate(4);
+
+        // Assert
+        Assert.Equal(4, callCount);
+        Assert.True(multiDelegateFired);
+    }
+
+    [Fact]
+    public void Navigated_EmptyCollection_OnFailedNavigation_DoesNotFire()
+    {
+        // Arrange
+        var navigator = new CollectionNavigator<string>(Array.Empty<string>());
+
+        int callCount = 0;
+        navigator.Navigated += @event => callCount++;
+
+        // Act
+        navigator.Next();
+        navigator.Previous();
+
+        // Assert
+        Assert.Equal(0, callCount);
     }
 
     #endregion

--- a/src/OSK.DataStructures/CollectionNavigator.cs
+++ b/src/OSK.DataStructures/CollectionNavigator.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using OSK.DataStructures.Events;
+using System;
 using System.Collections.Generic;
 
 namespace OSK.DataStructures;
@@ -29,13 +30,16 @@ public class CollectionNavigator<T>: ICollectionNavigator<T>
     #region ICollectionNavigator
 
     /// <inheritdoc/>
+    public event Action<CollectionNavigationEvent<T>>? Navigated;
+
+    /// <inheritdoc/>
     public bool WrapNavigation { get; }
 
     /// <inheritdoc/>
     public int Count => _items.Count;
 
     /// <inheritdoc/>
-    public T? Current => _items[CurrentIndex];
+    public T? Current => Count is 0 ? default : _items[CurrentIndex];
 
     /// <inheritdoc/>
     public int CurrentIndex { get; private set; }
@@ -58,6 +62,8 @@ public class CollectionNavigator<T>: ICollectionNavigator<T>
             ? WrapNavigation ? 0 : CurrentIndex
             : CurrentIndex + 1;
 
+        TryPublishNavigationEvent();
+
         return true;
     }
 
@@ -73,6 +79,8 @@ public class CollectionNavigator<T>: ICollectionNavigator<T>
             ? WrapNavigation ? Count - 1 : 0
             : CurrentIndex - 1;
 
+        TryPublishNavigationEvent();
+
         return true;
     }
 
@@ -85,7 +93,24 @@ public class CollectionNavigator<T>: ICollectionNavigator<T>
         }
 
         CurrentIndex = index;
+
+        TryPublishNavigationEvent();
+
         return true;
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private void TryPublishNavigationEvent()
+    {
+        Navigated?.Invoke(new()
+        {
+            Current = Current!,
+            CurrentIndex = CurrentIndex,
+            TotalItems = Count
+        });
     }
 
     #endregion

--- a/src/OSK.DataStructures/Events/CollectionNavigationEvent.cs
+++ b/src/OSK.DataStructures/Events/CollectionNavigationEvent.cs
@@ -1,0 +1,23 @@
+﻿namespace OSK.DataStructures.Events;
+
+/// <summary>
+/// An that is raised when collection navigation is performed
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public class CollectionNavigationEvent<T>
+{
+    /// <summary>
+    /// The current value the collection is at after navigation
+    /// </summary>
+    public required T Current { get; init; }
+
+    /// <summary>
+    /// The current index after navigation
+    /// </summary>
+    public required int CurrentIndex { get; init; }
+
+    /// <summary>
+    /// The total items in the navigated collection
+    /// </summary>
+    public required int TotalItems { get; init; }
+}

--- a/src/OSK.DataStructures/ICollectionNavigator.cs
+++ b/src/OSK.DataStructures/ICollectionNavigator.cs
@@ -1,4 +1,7 @@
-﻿namespace OSK.DataStructures;
+﻿using OSK.DataStructures.Events;
+using System;
+
+namespace OSK.DataStructures;
 
 /// <summary>
 /// A navigator over a collection of items
@@ -6,6 +9,11 @@
 /// <typeparam name="T">The data type the collection contains</typeparam>
 public interface ICollectionNavigator<T>
 {
+    /// <summary>
+    /// An event triggered when navigation occurs
+    /// </summary>
+    event Action<CollectionNavigationEvent<T>>? Navigated;
+
     /// <summary>
     /// Describes that navigator behavior if an end of the collection has been reached (i.e. start or finish). If set, the navigator will wrap around to the other end of the collection
     /// </summary>


### PR DESCRIPTION
Motivation
----
It would be helpful in some scenarios for users of the navigator to be called on navigation changes automatically

Modifications
----
* Added new CollectionNavigationEvent and related changes to navigator
* Updated unit tests

Result
----
A navigation event is now triggered on navigation with the navigator

Fixes #7